### PR TITLE
fix podmonitor podMetricsEndpoints

### DIFF
--- a/chart/k8stcpmap-controller/Chart.yaml
+++ b/chart/k8stcpmap-controller/Chart.yaml
@@ -11,4 +11,4 @@ keywords:
 name: k8stcpmap-controller
 sources:
 - https://github.com/DoodleScheduling/k8stcpmap-controller
-version: 0.1.1
+version: 0.1.2

--- a/chart/k8stcpmap-controller/templates/podmonitor.yaml
+++ b/chart/k8stcpmap-controller/templates/podmonitor.yaml
@@ -17,7 +17,7 @@ metadata:
   annotations:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
-  endpoints:
+  podMetricsEndpoints:
   - port: metrics
     path: {{ .Values.metricsPath }}
     interval: {{ .Values.podMonitor.interval }}


### PR DESCRIPTION
## Current situation
`endpoints` is invalid in podMonitor.

## Proposal
Update specs using podMetricsEndpoints.
